### PR TITLE
add --filesystem=home permission

### DIFF
--- a/org.kde.kmymoney.json
+++ b/org.kde.kmymoney.json
@@ -25,6 +25,7 @@
         "--socket=wayland",
         "--socket=fallback-x11",
         "--device=dri",
+        "--filesystem=home",
         "--system-talk-name=org.freedesktop.UDisks2"
     ],
     "modules": [


### PR DESCRIPTION
On my machine I could save a file successfully but I noticed there were some temp files accumulating that should have been deleted. In https://discuss.kde.org/t/kmymoney-cannot-find-initial-file/40351 a user said they couldn't save to a filename they chose. They said the problems they had were fixed by adding home filesystem permission in Flatseal.

I initially thought I would figure out a way to do the saving without requiring extra permissions. However, KMyMoney also can save backup files, which doesn't work correctly without filesystem permissions. I also found another user had problems with their aqbanking configuration not persisting when using the flatpak, which I am suspicious was caused by not being able to access the files it needed to: https://discuss.kde.org/t/kmymoney-missing-aqbanking-accounts-after-restart/40388

I wondered how GnuCash did since it is a similar program, and it has host filesystem access: https://github.com/flathub/org.gnucash.GnuCash/blob/master/org.gnucash.GnuCash.json#L16