### PR TITLE
update xmlsec1 from 1.3.7 to 1.3.8

### DIFF
--- a/org.kde.kmymoney.json
+++ b/org.kde.kmymoney.json
@@ -315,8 +315,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.7.tar.gz",
-                            "sha256": "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea",
+                            "url": "https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.8.tar.gz",
+                            "sha256": "d0180916ae71be28415a6fa919a0684433ec9ec3ba1cc0866910b02e5e13f5bd",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 5200,


### PR DESCRIPTION
I'm not sure why the bot didn't do this. I ran `flatpak run org.flathub.flatpak-external-data-checker --edit-only org.kde.kmymoney.json` locally to update it, so the x-checker-data seems to be fine.