### PR TITLE
Remove mm-common

### DIFF
--- a/org.kde.kmymoney.json
+++ b/org.kde.kmymoney.json
@@ -189,21 +189,6 @@
                     ],
                     "modules": [
                         {
-                            "name": "mm-common",
-                            "sources": [
-                                {
-                                    "type": "archive",
-                                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.7.tar.xz",
-                                    "sha256": "494abfce781418259b1e9d8888c73af4de4b6f3be36cc75d9baa8baa0f2a7a39",
-                                    "x-checker-data": {
-                                        "type": "gnome",
-                                        "name": "mm-common",
-                                        "stable-only": true
-                                    }
-                                }
-                            ]
-                        },
-                        {
                             "name": "glibmm",
                             "buildsystem": "meson",
                             "config-opts": [


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs, mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78