### PR TITLE
stay with QGpgME 2.0 until the runtime has gpgme 2.1

### DIFF
--- a/org.kde.kmymoney.json
+++ b/org.kde.kmymoney.json
@@ -48,6 +48,9 @@
                     "sha256": "15645b2475cca6118eb2ed331b3a8d9442c9d4019c3846ba3f6d25321b4a61ad",
                     "x-checker-data": {
                         "is-important": true,
+                        "versions": {
+                            "<": "2.1.0"
+                        },
                         "type": "anitya",
                         "project-id": 378538,
                         "stable-only": true,


### PR DESCRIPTION
stay with QGpgME 2.0 until the runtime has gpgme and gpgmepp 2.1